### PR TITLE
fix: update gitignore pattern and database build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,7 +106,7 @@ ehthumbs.db
 Thumbs.db
 
 # Prisma
-prisma/migrations/
+**/prisma/migrations/
 packages/database/src/generated/
 
 # Turborepo

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -12,7 +12,7 @@
     "studio": "prisma studio",
     "reset": "prisma migrate reset",
     "format": "prisma format",
-    "build": "tsc",
+    "build": "tsc --build",
     "test": "jest --passWithNoTests",
     "lint": "eslint src --ext .ts,.tsx",
     "seed": "tsc -p tsconfig.json && node dist/seed.js",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Broadens `.gitignore` to ignore Prisma migrations in any subdirectory and updates the database package build script to use `tsc --build`.
> 
> - **Repo configuration**:
>   - **.gitignore**: Change Prisma migrations ignore from `prisma/migrations/` to `**/prisma/migrations/`.
> - **Database package (`packages/database`)**:
>   - **Build script**: Switch `build` from `tsc` to `tsc --build`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be327ca2b7b9ecec09571838049e8c448c4364e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->